### PR TITLE
implement trainingjob controller without autoscaler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 matrix:
   include:
     - language: go
-      go: 1.8.x
+      go: 1.9.x
       sudo: required
       install:
         - go get -u github.com/golang/lint/golint

--- a/cmd/paddle_controller/paddle_controller.go
+++ b/cmd/paddle_controller/paddle_controller.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"time"
+
+	log "github.com/inconshreveable/log15"
+
+	"k8s.io/api/core/v1"
+	extcli "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+
+	paddleclientset "github.com/paddlepaddle/edl/pkg/client/clientset/versioned"
+	"github.com/paddlepaddle/edl/pkg/client/clientset/versioned/scheme"
+	paddleinformers "github.com/paddlepaddle/edl/pkg/client/informers/externalversions"
+	paddlecontroller "github.com/paddlepaddle/edl/pkg/controller"
+	"github.com/paddlepaddle/edl/pkg/signals"
+)
+
+var (
+	leaseDuration = 15 * time.Second
+	renewDuration = 5 * time.Second
+	retryPeriod   = 3 * time.Second
+)
+
+func main() {
+	masterURL := flag.String("master", "", "Address of a kube master.")
+	kubeConfig := flag.String("kubeconfig", "", "Path to a kube config. Only required if out-of-cluster.")
+	flag.Parse()
+
+	stopCh := signals.SetupSignalHandler()
+
+	cfg, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeConfig)
+	if err != nil {
+		log.Error("Error building kubeconfig:", err.Error())
+		return
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		log.Error("Error building kubernetes clientset:", err.Error())
+		return
+	}
+
+	extapiClient, err := extcli.NewForConfig(cfg)
+	if err != nil {
+		log.Error("Error building kubernetes extension api clientset:", err.Error())
+		return
+	}
+
+	paddleClient, err := paddleclientset.NewForConfig(cfg)
+	if err != nil {
+		log.Error("Error building paddle clientset:", err.Error())
+		return
+	}
+
+	paddleInformer := paddleinformers.NewSharedInformerFactory(paddleClient, time.Second*10)
+
+	controller := paddlecontroller.New(kubeClient, extapiClient, paddleClient, paddleInformer)
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Error("Error checking hostname:", err.Error())
+		return
+	}
+
+	go paddleInformer.Start(stopCh)
+
+	run := func(stop <-chan struct{}) {
+		log.Info("I won the leader election")
+		if controller.Run(1, stopCh); err != nil {
+			log.Error("Error running paddle trainingjob controller:", err.Error())
+			return
+		}
+	}
+
+	stop := func() {
+		log.Error("I lost the leader election")
+		return
+	}
+
+	leaderElectionClient, err := kubernetes.NewForConfig(rest.AddUserAgent(cfg, "leader-election"))
+	if err != nil {
+		log.Error("Error building leader election clientset:", err.Error())
+		return
+	}
+
+	// Prepare event clients.
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "trainingjob-controller"})
+
+	lock := &resourcelock.EndpointsLock{
+		EndpointsMeta: metav1.ObjectMeta{
+			Namespace: "kube-system",
+			Name:      "trainingjob-controller",
+		},
+		Client: leaderElectionClient.CoreV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity:      hostname,
+			EventRecorder: recorder,
+		},
+	}
+
+	leaderelection.RunOrDie(leaderelection.LeaderElectionConfig{
+		Lock:          lock,
+		LeaseDuration: leaseDuration,
+		RenewDeadline: renewDuration,
+		RetryPeriod:   retryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: run,
+			OnStoppedLeading: stop,
+		},
+	})
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 296c159ccdd668c756fe41dff9ea9ab17e3594860d9631d09e6cb4c945d2ae4e
-updated: 2018-03-15T13:48:14.132305441+08:00
+hash: 1c149a3466c9c44457b09421c5082134869e1ca80f6d6e292116650887de4514
+updated: 2018-04-08T14:29:39.032876083+08:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 782f4967f2dc4564575ca782fe2d04090b5faca8
@@ -22,7 +22,7 @@ imports:
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/go-stack/stack
-  version: 817915b46b97fd7bb80e8ab6b69f01a53ac3eebf
+  version: 259ab82a6cad3992b4e21ff5cac294ccb06474bc
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -30,6 +30,10 @@ imports:
   - sortkeys
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- name: github.com/golang/groupcache
+  version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
+  subpackages:
+  - lru
 - name: github.com/golang/protobuf
   version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
@@ -73,7 +77,7 @@ imports:
   - jlexer
   - jwriter
 - name: github.com/mattn/go-colorable
-  version: 7dc3415be66d7cc68bf0182f35c8d31f8d2ad8a7
+  version: efa589957cd060542a26d2dd7832fd6a6c6c3ade
 - name: github.com/mattn/go-isatty
   version: 6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
 - name: github.com/peterbourgon/diskv
@@ -123,7 +127,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/api
-  version: 389dfa299845bcf399c16af89987e8775718ea48
+  version: 3c2a58f9923aeb5d27fa4d91249e45a1460ca3bd
   subpackages:
   - admissionregistration/v1alpha1
   - apps/v1beta1
@@ -149,8 +153,16 @@ imports:
   - settings/v1alpha1
   - storage/v1
   - storage/v1beta1
+- name: k8s.io/apiextensions-apiserver
+  version: 996a70a27a0dcf53642ca52601b9107cb2ad810a
+  subpackages:
+  - pkg/apis/apiextensions
+  - pkg/apis/apiextensions/v1beta1
+  - pkg/client/clientset/clientset
+  - pkg/client/clientset/clientset/scheme
+  - pkg/client/clientset/clientset/typed/apiextensions/v1beta1
 - name: k8s.io/apimachinery
-  version: 019ae5ada31de202164b118aee88ee2d14075c31
+  version: 5134afd2c0c91158afac0d8a28bd2177185a3bcc
   subpackages:
   - pkg/api/equality
   - pkg/api/errors
@@ -183,22 +195,30 @@ imports:
   - pkg/util/diff
   - pkg/util/errors
   - pkg/util/framer
+  - pkg/util/httpstream
+  - pkg/util/httpstream/spdy
   - pkg/util/intstr
   - pkg/util/json
+  - pkg/util/mergepatch
   - pkg/util/net
+  - pkg/util/remotecommand
   - pkg/util/runtime
   - pkg/util/sets
+  - pkg/util/strategicpatch
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait
   - pkg/util/yaml
   - pkg/version
   - pkg/watch
+  - third_party/forked/golang/json
+  - third_party/forked/golang/netutil
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: 35874c597fed17ca62cd197e516d7d5ff9a2958c
+  version: 1b75876d45719a84085528ee621939b0c68a4b85
   subpackages:
   - discovery
+  - discovery/fake
   - kubernetes
   - kubernetes/scheme
   - kubernetes/typed/admissionregistration/v1alpha1
@@ -228,20 +248,25 @@ imports:
   - pkg/version
   - rest
   - rest/watch
+  - testing
   - tools/auth
   - tools/cache
   - tools/clientcmd
   - tools/clientcmd/api
   - tools/clientcmd/api/latest
   - tools/clientcmd/api/v1
+  - tools/leaderelection
+  - tools/leaderelection/resourcelock
   - tools/metrics
   - tools/pager
+  - tools/record
   - tools/reference
   - transport
   - util/cert
   - util/flowcontrol
   - util/homedir
   - util/integer
+  - util/workqueue
 - name: k8s.io/code-generator
   version: 25fd8c8ddbf75b223882df4479f8b8e615da05ae
 - name: k8s.io/kube-openapi
@@ -249,7 +274,7 @@ imports:
   subpackages:
   - pkg/common
 - name: k8s.io/kubernetes
-  version: 64d864fe1e881f935c6b1f46641daee7f24552cf
+  version: 4934fa77053c70738f2a81e991b07f773af1c0f0
   subpackages:
   - pkg/api
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,13 +1,19 @@
 package: github.com/paddlepaddle/edl
 import:
+- package: github.com/wangkuiyi/candy
 - package: k8s.io/client-go
-  version: kubernetes-1.8.0
+  version: kubernetes-1.8.6
 - package: k8s.io/kubernetes
   version: release-1.8
 - package: k8s.io/api
   version: release-1.8
-- package: github.com/inconshreveable/log15
-  version: v2.13
-- package: github.com/wangkuiyi/candy
 - package: k8s.io/code-generator
   version: kubernetes-1.8.6
+- package: k8s.io/apiextensions-apiserver
+  version: kubernetes-1.8.6
+- package: github.com/inconshreveable/log15
+  version: v2.13
+- package: github.com/golang/groupcache
+  subpackages:
+  - lru
+

--- a/pkg/controller/trainingjob_controller.go
+++ b/pkg/controller/trainingjob_controller.go
@@ -1,0 +1,260 @@
+package controller
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	log "github.com/inconshreveable/log15"
+
+	corev1 "k8s.io/api/core/v1"
+	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+
+	paddlev1 "github.com/paddlepaddle/edl/pkg/apis/paddlepaddle/v1"
+	paddleclient "github.com/paddlepaddle/edl/pkg/client/clientset/versioned"
+	paddlescheme "github.com/paddlepaddle/edl/pkg/client/clientset/versioned/scheme"
+	paddleinformers "github.com/paddlepaddle/edl/pkg/client/informers/externalversions"
+	paddlelisters "github.com/paddlepaddle/edl/pkg/client/listers/paddlepaddle/v1"
+	"github.com/paddlepaddle/edl/pkg/updater"
+)
+
+// TrainingJobController defines the structure to manage TrainingJob resource
+type TrainingJobController struct {
+	// KubeCli is a standard kubernetes clientset
+	KubeCli kubernetes.Interface
+	// ExtCli is the extension kubernetes clientset
+	ExtCli extclient.Interface
+	// PaddleCli is a clientset for our own API group
+	PaddleCli paddleclient.Interface
+
+	trainingjobLister paddlelisters.TrainingJobLister
+	trainingjobSynced cache.InformerSynced
+
+	// jobupdater is the collection of job updaters for each training job
+	jobupdater *sync.Map
+
+	// workqueue is a rate limited work queue. This is used to queue work to be
+	// processed instead of performing it as soon as a change happens.
+	workqueue workqueue.RateLimitingInterface
+	// recorder is an event recorder for recording Event resources to the
+	// Kubernetes API.
+	recorder record.EventRecorder
+}
+
+// New returns a trainingjob controller
+func New(
+	kubeCli kubernetes.Interface,
+	extCli extclient.Interface,
+	paddleCli paddleclient.Interface,
+	paddleInformers paddleinformers.SharedInformerFactory) *TrainingJobController {
+	trainingjobInformer := paddleInformers.Paddlepaddle().V1().TrainingJobs()
+	paddlescheme.AddToScheme(scheme.Scheme)
+
+	log.Info("Creating trainingjob event broadcaster")
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(log.Info)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeCli.CoreV1().Events("")})
+	workqueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "TrainingJob")
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "TrainingJobController"})
+
+	controller := &TrainingJobController{
+		KubeCli:           kubeCli,
+		ExtCli:            extCli,
+		PaddleCli:         paddleCli,
+		trainingjobLister: trainingjobInformer.Lister(),
+		trainingjobSynced: trainingjobInformer.Informer().HasSynced,
+		jobupdater:        new(sync.Map),
+		workqueue:         workqueue,
+		recorder:          recorder,
+	}
+
+	log.Info("Setting up event handlers")
+	trainingjobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: controller.enqueue,
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldTj := oldObj.(*paddlev1.TrainingJob)
+			newTj := newObj.(*paddlev1.TrainingJob)
+			objNs := oldTj.Namespace
+			objName := oldTj.Name
+			if oldTj.ResourceVersion == newTj.ResourceVersion {
+				log.Debug("same resourceversion for training job", objNs, "/", objName, ", skipped")
+				return
+			}
+			log.Debug("resourceversion for training job", objNs, "/", objName, "updated")
+			controller.enqueue(newObj)
+		},
+		DeleteFunc: controller.dequeue,
+	})
+
+	return controller
+}
+
+// Run will set up the event handlers for trainingjob, as well as syncing
+// informer caches and starting workers. It will block until stopCh
+// is closed, at which point it will shutdown the workqueue and wait for
+// workers to finish processing their current work items.
+func (c *TrainingJobController) Run(threadiness int, stopCh <-chan struct{}) error {
+	// TODO add a lock to ensure there is only one controller in the cluster
+	defer runtime.HandleCrash()
+	defer c.workqueue.ShutDown()
+
+	log.Info("Starting to create custom resource definition")
+
+	if err := c.createCRD(); err != nil {
+		return fmt.Errorf("failed to create kind TrainingJob: %v", err)
+	}
+
+	log.Info("Waiting for informer caches to sync")
+	if ok := cache.WaitForCacheSync(stopCh, c.trainingjobSynced); !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	log.Info("Starting workers")
+	for i := 0; i < threadiness; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+
+	log.Info("Started workers")
+	<-stopCh
+	log.Info("Shutting down workers")
+
+	return nil
+}
+
+func (c *TrainingJobController) createCRD() error {
+	crd := &extv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: paddlev1.CRDName(),
+		},
+		Spec: extv1beta1.CustomResourceDefinitionSpec{
+			Group:   paddlev1.CRDGroup,
+			Version: paddlev1.CRDVersion,
+			Scope:   extv1beta1.NamespaceScoped,
+			Names: extv1beta1.CustomResourceDefinitionNames{
+				Kind:       paddlev1.CRDKind,
+				Plural:     paddlev1.CRDKindPlural,
+				ShortNames: []string{paddlev1.CRDShortName},
+			},
+		},
+	}
+
+	_, err := c.ExtCli.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		log.Error("Failed to create crd, error", err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// enqueue takes a TrainingJob resource and converts it into a namespace/name
+// string which is then put onto the work queue.
+func (c *TrainingJobController) enqueue(obj interface{}) {
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	log.Info("enqueue key:", key)
+	c.workqueue.AddRateLimited(key)
+}
+
+func (c *TrainingJobController) dequeue(obj interface{}) {
+	job, ok := obj.(*paddlev1.TrainingJob)
+	if !ok {
+		runtime.HandleError(fmt.Errorf("type conversion error: %+v", obj))
+		return
+	}
+	key := job.Namespace + "/" + job.Name
+	log.Info("dequeue key:", key)
+	jobToDelete, ok := c.jobupdater.Load(key)
+	if !ok {
+		log.Warn("unsafe state.", key, "was never created but we received delete event")
+		return
+	}
+
+	oldtj := jobToDelete.(*updater.TrainingJobUpdater)
+	oldtj.Delete()
+	c.jobupdater.Delete(key)
+}
+
+func (c *TrainingJobController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *TrainingJobController) processNextWorkItem() bool {
+	obj, shutdown := c.workqueue.Get()
+
+	if shutdown {
+		return false
+	}
+
+	err := func(obj interface{}) error {
+		defer c.workqueue.Done(obj)
+		var key string
+		var ok bool
+		if key, ok = obj.(string); !ok {
+			c.workqueue.Forget(obj)
+			runtime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			return nil
+		}
+
+		if err := c.syncHandler(key); err != nil {
+			return fmt.Errorf("error syncing '%s': %s", key, err.Error())
+		}
+
+		c.workqueue.Forget(obj)
+		log.Info("Successfully synced", key)
+		return nil
+	}(obj)
+
+	if err != nil {
+		runtime.HandleError(err)
+		return true
+	}
+
+	return true
+}
+
+func (c *TrainingJobController) syncHandler(key string) error {
+	log.Info("syncHandler, key:", key)
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		return nil
+	}
+	log.Info("syncHandler for ", ns, "/", name)
+
+	job, createErr := c.trainingjobLister.TrainingJobs(ns).Get(name)
+	if createErr != nil {
+		log.Error("get trainingjob error:", err.Error())
+		if apierrors.IsNotFound(err) {
+			runtime.HandleError(fmt.Errorf("trainingjob '%s' in the work queue no longer exists", key))
+			return nil
+		}
+
+		return err
+	}
+
+	_, ok := c.jobupdater.Load(key)
+	if !ok {
+		log.Info("create new job updater, key:", key)
+		nj, _ := updater.NewUpdater(job, c.KubeCli, c.PaddleCli)
+		c.jobupdater.Store(key, nj)
+	}
+
+	return nil
+}

--- a/pkg/signals/signal.go
+++ b/pkg/signals/signal.go
@@ -1,0 +1,30 @@
+package signals
+
+import (
+	"os"
+	"os/signal"
+)
+
+var (
+	onlyOneSignalHandler = make(chan struct{})
+	shutdownSignals      = []os.Signal{os.Interrupt}
+)
+
+// SetupSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
+// which is closed on one of these signals. If a second signal is caught, the program
+// is terminated with exit code 1.
+func SetupSignalHandler() (stopCh <-chan struct{}) {
+	close(onlyOneSignalHandler) // panics when called twice
+
+	stop := make(chan struct{})
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, shutdownSignals...)
+	go func() {
+		<-c
+		close(stop)
+		<-c
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return stop
+}

--- a/pkg/updater/trainingJobUpdater.go
+++ b/pkg/updater/trainingJobUpdater.go
@@ -2,6 +2,9 @@ package updater
 
 import (
 	"fmt"
+	"reflect"
+	"time"
+
 	log "github.com/golang/glog"
 	padv1 "github.com/paddlepaddle/edl/pkg/apis/paddlepaddle/v1"
 	trainingJobClient "github.com/paddlepaddle/edl/pkg/client/clientset/versioned"
@@ -9,8 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"reflect"
-	"time"
 )
 
 const (


### PR DESCRIPTION
This pull request implements a training job controller without autoscaler, which registers a self-defined resource called `TrainingJob` and then watches the event of `TrainingJob` to manage the lifecycle of `TrainingJob` instance.