### PR TITLE
Update .travis.yml to fix url error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
       go: 1.8.x
       sudo: required
       install:
-        - go get -u github.com/golang/lint/golint
+        - go get -u golang.org/x/lint/golint
         - curl https://glide.sh/get | bash
         - sudo pip install pre-commit
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 matrix:
   include:
     - language: go
-      go: 1.8.x
+      go: 1.9.x
       sudo: required
       install:
         - go get -u golang.org/x/lint/golint


### PR DESCRIPTION
### error
```
$ go get -u github.com/golang/lint/golint
# golang.org/x/tools/go/internal/gcimporter
../../../golang.org/x/tools/go/internal/gcimporter/bexport.go:212: obj.IsAlias undefined (type *types.TypeName has no field or method IsAlias)
../../../golang.org/x/tools/go/internal/gcimporter/iexport.go:221: obj.IsAlias undefined (type *types.TypeName has no field or method IsAlias)
The command "go get -u github.com/golang/lint/golint" failed and exited with 2 during .
```
https://travis-ci.org/PaddlePaddle/edl/builds/594942222?utm_source=github_status&utm_medium=notification

### reason
https://github.com/golang/lint/issues/421#issuecomment-432304663
> Go 1.8 is no longer supported by the Go team. We only support the current release and one previous