### PR TITLE
Refine etcd client, register, add discovery to python pkg

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB_RECURSE EDL_FILES collective/*.py demo/*.py demo/*.sh setup.py)
+file(GLOB_RECURSE EDL_FILES collective/*.py demo/*.py demo/*.sh discovery/*.py setup.py)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
 add_custom_command(
 	OUTPUT ${EDL_BINARY_DIR}/.timestamp

--- a/python/paddle_edl/discovery/etcd_client.py
+++ b/python/paddle_edl/discovery/etcd_client.py
@@ -25,6 +25,18 @@ class NoValidEndpoint(Exception):
     pass
 
 
+class ServerMeta(object):
+    def __init__(self, server, info, mod_revision, revision):
+        self.server = server
+        self.info = info
+        self.mod_revision = mod_revision  # key mod revision
+        self.revision = revision  # etcd global revision
+
+    def __str__(self):
+        return 'server={}, info={}, mod_revision={}, revision={}'.\
+            format(self.server, self.info, self.mod_revision, self.revision)
+
+
 def _handle_errors(f):
     def handler(*args, **kwargs):
         try:
@@ -78,15 +90,63 @@ class EtcdClient(object):
         servers = []
         d = '/{}/{}/nodes/'.format(self._root, service_name)
         for value, meta in self._etcd.get_prefix(d):
-            servers.append([
-                self.get_server_name_from_full_path(meta.key, service_name),
-                value
-            ])
+            servers.append(
+                ServerMeta(
+                    self.get_server_name_from_full_path(
+                        meta.key, service_name), value, meta.mod_revision,
+                    meta.response_header.revision))
         return servers
 
-    def watch_service(self, service_name, call_back):
+    @_handle_errors
+    def get_service_with_revision(self, service_name):
+        servers = []
+        d = '/{}/{}/nodes/'.format(self._root, service_name)
+
+        key_prefix = d
+        range_response = self._etcd.get_prefix_response(key_prefix)
+        for kv in range_response.kvs:
+            servers.append(
+                ServerMeta(
+                    self.get_server_name_from_full_path(kv.key, service_name),
+                    kv.value, kv.mod_revision, range_response.header.revision))
+
+        return servers, range_response.header.revision
+
+    def watch_service(self, service_name, call_back, **kwargs):
+        # call_back(add_servers, rm_servers)
+        #   add_servers: list(ServerMeta)
+        #   rm_servers: list(ServerMeta)
+        # start_revision=, watch start from revision
+        def services_change(response):
+            add_servers = dict()
+            rm_servers = dict()
+            for event in response.events:
+                key = self.get_server_name_from_full_path(event.key,
+                                                          service_name)
+                server = ServerMeta(key, event.value, event.mod_revision,
+                                    response.header.revision)
+
+                if isinstance(event, etcd.events.PutEvent):
+                    if key in rm_servers:
+                        # after rm key, add again, need remove key from rm set
+                        rm_servers.pop(key)
+                    add_servers[key] = server
+                elif isinstance(event, etcd.events.DeleteEvent):
+                    if key in add_servers:
+                        # after add key, rm again, need remove key from add dict
+                        add_servers.pop(key)
+                    rm_servers[key] = server
+                else:
+                    raise TypeError('ectd event type is not put or delete!')
+
+            if len(add_servers) == 0 and len(rm_servers) == 0:
+                return
+
+            call_back(add_servers.values(), rm_servers.values())
+
         d = '/{}/{}/'.format(self._root, service_name)
-        return self._etcd.add_watch_prefix_callback(d, call_back)
+        return self._etcd.add_watch_prefix_callback(d, services_change,
+                                                    **kwargs)
 
     def cancel_watch(self, watch_id):
         return self._etcd.cancel_watch(watch_id)
@@ -140,6 +200,13 @@ class EtcdClient(object):
         key = '/{}/{}/nodes/{}'.format(self._root, service_name, server)
         lease = self._get_lease(key, ttl)
         return self._etcd.put(key=key, value=info, lease=lease)
+
+    @_handle_errors
+    def _get_server(self, service_name, server):
+        # for debug
+        key = '/{}/{}/nodes/{}'.format(self._root, service_name, server)
+        value, meta = self._etcd.get(key=key)
+        return value, meta.key, meta.version, meta.create_revision, meta.mod_revision
 
     @_handle_errors
     def remove_server(self, service_name, server):

--- a/python/paddle_edl/discovery/server_alive.py
+++ b/python/paddle_edl/discovery/server_alive.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import socket
+from contextlib import closing
+
+
+def is_server_alive(server):
+    """ is server alive
+    return alive, client_addr
+    """
+    alive = True
+    client_addr = None
+    ip, port = server.split(":")
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        try:
+            s.settimeout(1.5)
+            s.connect((ip, int(port)))
+            client_addr = s.getsockname()
+            s.shutdown(socket.SHUT_RDWR)
+        except socket.error:
+            alive = False
+        return alive, client_addr

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -47,7 +47,8 @@ REQUIRED_PACKAGES = [
 packages=['paddle_edl', 
           'paddle_edl.collective', 
           'paddle_edl.demo', 
-          'paddle_edl.demo.collective']
+          'paddle_edl.demo.collective',
+          'paddle_edl.discovery']
 
 setup(
     name='paddle_edl',


### PR DESCRIPTION
Split from https://github.com/elasticdeeplearning/edl/pull/78

1. Refine etcd client.
  - get_service return ServerMeta, include {server, info, mod_revision, revision}. 
  - Add get_service_with_revision, even if servers is None, revision will also return.
  - watch_service add kwargs, can watch from revision.  Change callback signature to (add_servers, rm_servers)
2. Refine register.
3. Add discovery to python pkg.